### PR TITLE
:zap: :art: Proposal of code removal in Header. Redundant variable.

### DIFF
--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -6,6 +6,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    MutableMapping,
     Optional,
     Tuple,
     Type,
@@ -66,7 +67,7 @@ class Header(object):
         ]
 
         self._not_valued_attrs: List[str] = list()
-        self._valued_attrs: CaseInsensitiveDict[str, Union[str, List[str]]] = CaseInsensitiveDict()
+        self._valued_attrs: MutableMapping[str, Union[str, List[str]]] = CaseInsensitiveDict()
 
         for member in self._members:
             if member == "":

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -441,6 +441,15 @@ class Header(object):
     def get(self, attr: str) -> Optional[Union[str, List[str]]]:
         """
         Retrieve associated value of an attribute.
+        >>> header = Header("Content-Type", "application/json; charset=UTF-8; format=flowed")
+        >>> header.charset
+        'UTF-8'
+        >>> header.ChArSeT
+        'UTF-8'
+        >>> header.FORMAT
+        'flowed'
+        >>> header.format
+        'flowed'
         """
         if attr not in self._valued_attrs:
             return None

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -67,7 +67,9 @@ class Header(object):
         ]
 
         self._not_valued_attrs: List[str] = list()
-        self._valued_attrs: MutableMapping[str, Union[str, List[str]]] = CaseInsensitiveDict()
+        self._valued_attrs: MutableMapping[
+            str, Union[str, List[str]]
+        ] = CaseInsensitiveDict()
 
         for member in self._members:
             if member == "":
@@ -465,7 +467,9 @@ class Header(object):
         This method will allow you to retrieve attribute value using the bracket syntax, list-like.
         """
         if isinstance(item, int):
-            return self._members[item] if not OUTPUT_LOCK_TYPE else [self._members[item]]
+            return (
+                self._members[item] if not OUTPUT_LOCK_TYPE else [self._members[item]]
+            )
 
         if item in self._valued_attrs:
             value = self._valued_attrs[item]
@@ -492,9 +496,7 @@ class Header(object):
         """
         item = unpack_protected_keyword(item)
 
-        if (
-            item not in self._valued_attrs
-        ):
+        if item not in self._valued_attrs:
             raise AttributeError(
                 "'{item}' attribute is not defined within '{header}' header.".format(
                     item=item, header=self.name

--- a/kiss_headers/structures.py
+++ b/kiss_headers/structures.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping
 from typing import Any, Iterator, Optional, Tuple
+
 from kiss_headers.utils import normalize_str
 
 

--- a/kiss_headers/structures.py
+++ b/kiss_headers/structures.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping
 from typing import Any, Iterator, Optional, Tuple
+from kiss_headers.utils import normalize_str
 
 
 """
@@ -45,13 +46,13 @@ class CaseInsensitiveDict(MutableMapping):
     def __setitem__(self, key: str, value: Any) -> None:
         # Use the lowercased key for lookups, but store the actual
         # key alongside the value.
-        self._store[key.lower().replace("-", "_")] = (key, value)
+        self._store[normalize_str(key)] = (key, value)
 
     def __getitem__(self, key: str) -> Any:
-        return self._store[key.lower().replace("-", "_")][1]
+        return self._store[normalize_str(key)][1]
 
     def __delitem__(self, key: str) -> None:
-        del self._store[key.lower().replace("-", "_")]
+        del self._store[normalize_str(key)]
 
     def __iter__(self) -> Iterator[Tuple[str, Any]]:
         return (casedkey for casedkey, mappedvalue in self._store.values())


### PR DESCRIPTION
Using _valued_attrs_normalized in Header was a mistake. It is obvious that _valued_attrs should be a CaseInsensitiveDict.

## Pull Request

### My patch is about
- [ ] :bug: Bugfix 
- [x] :arrow_up: Improvement
- [ ] :pencil: Documentation
- [ ] :heavy_check_mark: Tests
- [ ] :sparkle: Feature

### Checklist
- [x] I accept that my PR will be distributed under the MIT license.
- [ ] Test cases added for changed code if necessary.


## Describe what you have changed in this PR.

`Header` class possess two members, respectively named `_valued_attrs` and `_unvalued_attrs`. The class could behave the same if `_valued_attrs` was a `CaseInsensitiveDict`.