### PR TITLE
:sparkle: :tada: Allow to parse headers that are UTF-8 encoded.

### DIFF
--- a/kiss_headers/api.py
+++ b/kiss_headers/api.py
@@ -8,6 +8,7 @@ from kiss_headers.structures import CaseInsensitiveDict
 from kiss_headers.utils import (
     decode_partials,
     extract_class_name,
+    extract_encoded_headers,
     header_content_split,
     header_name_to_class,
     is_legal_header_name,
@@ -27,14 +28,8 @@ def parse_it(raw_headers: Any) -> Headers:
     if isinstance(raw_headers, str):
         headers = HeaderParser().parsestr(raw_headers, headersonly=True).items()
     elif isinstance(raw_headers, bytes) or isinstance(raw_headers, IOBase):
-        headers = (
-            BytesHeaderParser()
-            .parse(
-                BytesIO(raw_headers) if isinstance(raw_headers, bytes) else raw_headers,  # type: ignore
-                headersonly=True,
-            )
-            .items()
-        )
+        decoded, not_decoded = extract_encoded_headers(raw_headers if isinstance(raw_headers, bytes) else raw_headers.read())
+        return parse_it(decoded)
     elif isinstance(raw_headers, Mapping) or isinstance(raw_headers, Message):
         headers = raw_headers.items()
     else:

--- a/kiss_headers/api.py
+++ b/kiss_headers/api.py
@@ -1,6 +1,6 @@
 from email.message import Message
-from email.parser import BytesHeaderParser, HeaderParser
-from io import BytesIO, IOBase
+from email.parser import HeaderParser
+from io import RawIOBase
 from typing import Any, Iterable, List, Mapping, Optional, Tuple
 
 from kiss_headers.models import Header, Headers
@@ -27,8 +27,8 @@ def parse_it(raw_headers: Any) -> Headers:
 
     if isinstance(raw_headers, str):
         headers = HeaderParser().parsestr(raw_headers, headersonly=True).items()
-    elif isinstance(raw_headers, bytes) or isinstance(raw_headers, IOBase):
-        decoded, not_decoded = extract_encoded_headers(raw_headers if isinstance(raw_headers, bytes) else raw_headers.read())
+    elif isinstance(raw_headers, bytes) or isinstance(raw_headers, RawIOBase):
+        decoded, not_decoded = extract_encoded_headers(raw_headers if isinstance(raw_headers, bytes) else raw_headers.read() or b'')
         return parse_it(decoded)
     elif isinstance(raw_headers, Mapping) or isinstance(raw_headers, Message):
         headers = raw_headers.items()

--- a/kiss_headers/api.py
+++ b/kiss_headers/api.py
@@ -28,7 +28,9 @@ def parse_it(raw_headers: Any) -> Headers:
     if isinstance(raw_headers, str):
         headers = HeaderParser().parsestr(raw_headers, headersonly=True).items()
     elif isinstance(raw_headers, bytes) or isinstance(raw_headers, RawIOBase):
-        decoded, not_decoded = extract_encoded_headers(raw_headers if isinstance(raw_headers, bytes) else raw_headers.read() or b'')
+        decoded, not_decoded = extract_encoded_headers(
+            raw_headers if isinstance(raw_headers, bytes) else raw_headers.read() or b""
+        )
         return parse_it(decoded)
     elif isinstance(raw_headers, Mapping) or isinstance(raw_headers, Message):
         headers = raw_headers.items()

--- a/kiss_headers/utils.py
+++ b/kiss_headers/utils.py
@@ -395,12 +395,12 @@ def extract_encoded_headers(payload: bytes) -> Tuple[str, bytes]:
     index: int = 0
 
     for line, index in zip(lines, range(0, len(lines))):
-        if line == b'':
-            return result, b'\r\n'.join(lines[index:])
+        if line == b"":
+            return result, b"\r\n".join(lines[index:])
 
         try:
-            result += line.decode("utf-8") + '\r\n'
+            result += line.decode("utf-8") + "\r\n"
         except UnicodeDecodeError:
             break
 
-    return result, b'\r\n'.join(lines[index:])
+    return result, b"\r\n".join(lines[index:])

--- a/kiss_headers/utils.py
+++ b/kiss_headers/utils.py
@@ -381,3 +381,26 @@ def extract_comments(content: str) -> List[str]:
     ['Macintosh; Intel Mac OS X 10.9; rv:50.0', 'hello', 'abc']
     """
     return findall(r"\(([^)]+)\)", content)
+
+
+def extract_encoded_headers(payload: bytes) -> Tuple[str, bytes]:
+    """This function purpose is to extract lines that can be decoded using utf-8.
+    >>> extract_encoded_headers("Host: developer.mozilla.org\\r\\nX-Hello-World: 死の漢字\\r\\n\\r\\n".encode("utf-8"))
+    ('Host: developer.mozilla.org\\r\\nX-Hello-World: 死の漢字\\r\\n', b'')
+    >>> extract_encoded_headers("Host: developer.mozilla.org\\r\\nX-Hello-World: 死の漢字\\r\\n\\r\\nThat IS totally random.".encode("utf-8"))
+    ('Host: developer.mozilla.org\\r\\nX-Hello-World: 死の漢字\\r\\n', b'\\r\\nThat IS totally random.')
+    """
+    result: str = ""
+    lines: List[bytes] = payload.splitlines()
+    index: int = 0
+
+    for line, index in zip(lines, range(0, len(lines))):
+        if line == b'':
+            return result, b'\r\n'.join(lines[index:])
+
+        try:
+            result += line.decode("utf-8") + '\r\n'
+        except UnicodeDecodeError:
+            break
+
+    return result, b'\r\n'.join(lines[index:])

--- a/tests/test_headers_from_string.py
+++ b/tests/test_headers_from_string.py
@@ -57,8 +57,7 @@ class MyKissHeadersFromStringTest(unittest.TestCase):
     def test_bytes_headers(self):
 
         self.assertEqual(
-            MyKissHeadersFromStringTest.headers,
-            parse_it(RAW_HEADERS.encode("utf-8"))
+            MyKissHeadersFromStringTest.headers, parse_it(RAW_HEADERS.encode("utf-8"))
         )
 
     def test_two_headers_eq(self):

--- a/tests/test_headers_from_string.py
+++ b/tests/test_headers_from_string.py
@@ -54,6 +54,13 @@ class MyKissHeadersFromStringTest(unittest.TestCase):
             decode_partials([("Subject", "=?iso-8859-1?q?p=F6stal?=")]),
         )
 
+    def test_bytes_headers(self):
+
+        self.assertEqual(
+            MyKissHeadersFromStringTest.headers,
+            parse_it(RAW_HEADERS.encode("utf-8"))
+        )
+
     def test_two_headers_eq(self):
 
         self.assertEqual(MyKissHeadersFromStringTest.headers, parse_it(RAW_HEADERS))


### PR DESCRIPTION
## Pull Request

### My patch is about
- [ ] :bug: Bugfix 
- [ ] :arrow_up: Improvement
- [ ] :pencil: Documentation
- [ ] :heavy_check_mark: Tests
- [x] :sparkle: Feature

### Checklist
- [x] I accept that my PR will be distributed under the MIT license.
- [x] Test cases added for changed code if necessary.


## Describe what you have changed in this PR.

The package use `HeaderParser` available from the stdlib to initially parse headers from raw content. But it does not provide support for UTF-8 encoded headers. That why I propose this PR.

I created `extract_encoded_headers` in **utils.py** that will decode lines using UTF-8 encoding, and them call recursively `parse_it` using this time, **str** instead of **bytes**.