### PR TITLE
:sparkle: Unfold header attribute value by default

### DIFF
--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -24,6 +24,7 @@ from kiss_headers.utils import (
     prettify_header_name,
     unpack_protected_keyword,
     unquote,
+    unfold,
 )
 
 OUTPUT_LOCK_TYPE: bool = False
@@ -473,7 +474,7 @@ class Header(object):
 
     def __getitem__(self, item: Union[str, int]) -> Union[str, List[str]]:
         """
-        This method will allow you to retrieve attribute value using the bracket syntax, list-like.
+        This method will allow you to retrieve attribute value using the bracket syntax, list-like or dict-like.
         """
         if isinstance(item, int):
             return (
@@ -493,9 +494,9 @@ class Header(object):
             value = [value]
 
         return (
-            unquote(value)
+            unfold(unquote(value))
             if not isinstance(value, list)
-            else [unquote(v) for v in value]
+            else [unfold(unquote(v)) for v in value]
         )
 
     def __getattr__(self, item: str) -> Union[str, List[str]]:

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -22,9 +22,9 @@ from kiss_headers.utils import (
     is_legal_header_name,
     normalize_str,
     prettify_header_name,
+    unfold,
     unpack_protected_keyword,
     unquote,
-    unfold,
 )
 
 OUTPUT_LOCK_TYPE: bool = False

--- a/kiss_headers/utils.py
+++ b/kiss_headers/utils.py
@@ -383,6 +383,15 @@ def extract_comments(content: str) -> List[str]:
     return findall(r"\(([^)]+)\)", content)
 
 
+def unfold(content: str) -> str:
+    """Some header content may have folded content (LF + 9 spaces or LF + 7 spaces) in it, making your job at reading them a little more difficult.
+    This function undo the folding in given content.
+    >>> unfold("eqHS2AQD+hfNNlTiLej73CiBUGVQifX4watAaxUkdjGeH578i7n3Wwcdw2nLz+U0bH\\n         ehSe/2QytZGWM5CewwNdumT1IVGzjFs+cRgfK0V6JlEIOoV3bRXxnjenWFfWdVNXtw8s")
+    'eqHS2AQD+hfNNlTiLej73CiBUGVQifX4watAaxUkdjGeH578i7n3Wwcdw2nLz+U0bHehSe/2QytZGWM5CewwNdumT1IVGzjFs+cRgfK0V6JlEIOoV3bRXxnjenWFfWdVNXtw8s'
+    """
+    return content.replace("\n" + (9 * " "), "").replace("\n" + (7 * " "), " ")
+
+
 def extract_encoded_headers(payload: bytes) -> Tuple[str, bytes]:
     """This function purpose is to extract lines that can be decoded using utf-8.
     >>> extract_encoded_headers("Host: developer.mozilla.org\\r\\nX-Hello-World: 死の漢字\\r\\n\\r\\n".encode("utf-8"))


### PR DESCRIPTION
## Pull Request

### My patch is about
- [ ] :bug: Bugfix 
- [ ] :arrow_up: Improvement
- [ ] :pencil: Documentation
- [ ] :heavy_check_mark: Tests
- [x] :sparkle: Feature

### Checklist
- [x] I accept that my PR will be distributed under the MIT license.
- [x] Test cases added for changed code if necessary.


## Describe what you have changed in this PR.

Sometime an header can have folded content. This PR allow end-user to get attribute value unfolded by default. It won't alter original content. Still can accessible from `content` property of Header.