### PR TITLE
[Feature] More precise way to alter/handle attributes within Header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 cache: pip
 
 python:
+  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
@@ -11,6 +12,7 @@ python:
 
 jobs:
   allow_failures:
+  - python: "3.5"
   - python: "3.9-dev"  # See https://github.com/python/mypy/issues/8627
   - python: "pypy3"
 

--- a/README.md
+++ b/README.md
@@ -48,19 +48,20 @@ charset = headers['Content-Type'].split(';')[-1].split('=')[-1].replace('"', '')
 
 * A backwards-compatible syntax using bracket style.
 * Capability to alter headers using simple, human-readable operator notation `+` and `-`.
-* Flexibility if headers are from IMAP4 or HTTP, use as you need with one library.
-* Ability to parse any object and extract recognized headers from it, it also support UTF-8 encoded headers.
+* Flexibility if headers are from an email or HTTP, use as you need with one library.
+* Ability to parse any object and extract recognized headers from it, it also supports UTF-8 encoded headers.
 * Fully type-annotated.
 * Provide great auto-completion in Python interpreter or any capable IDE.
-* Absolutely no dependencies.
+* No dependencies. And never will be.
 * 90% test coverage.
 
 Plus all the features that you would expect from handling headers...
 
 * Properties syntax for headers and attribute in header.
 * Supports headers and attributes OneToOne, OneToMany and ManySquashedIntoOne.
-* Capable of parsing `bytes`, `fp`, `str`, `dict`, `email.Message`, `requests.Response` and `httpx._models.Response`.
-* Automatically unquote and unfold value of an attribute when retrieving it.
+* Capable of parsing `bytes`, `fp`, `str`, `dict`, `email.Message`, `requests.Response`, `httpx._models.Response` and `urllib3.HTTPResponse`.
+* Automatically unquote and unfold the value of an attribute when retrieving it.
+* Keep headers and attributes ordering.
 * Case insensitive with header name and attribute key.
 * Character `-` equal `_` in addition of above feature.
 * Any syntax you like, we like.
@@ -104,7 +105,7 @@ headers.set_cookie[0]._1p_jar # output: 2020-03-16-21
 headers.set_cookie[0]["1P_JAR"] # output: 2020-03-16-21
 ```
 
-Since v2.1 you can transform an Header object to its target `CustomHeader` subclass in order to access more methods.
+Since v2.1 you can transform an Header object to its target `CustomHeader` subclass to access more methods.
 
 ```python
 from kiss_headers import parse_it, get_polymorphic, SetCookie

--- a/kiss_headers/__init__.py
+++ b/kiss_headers/__init__.py
@@ -2,7 +2,7 @@
 Kiss-Headers
 ~~~~~~~~~~~~~~
 
-Kiss-Headers is a headers, HTTP or IMAP4 _(message, email)_ flavour, utility, written in Python, for humans.
+Kiss-Headers is a headers, HTTP or IMAP4 _(message, email)_ flavour, utility, written in pure Python, for humans.
 Object oriented headers. Keep it sweet and simple.
 Basic usage:
 
@@ -87,5 +87,5 @@ from kiss_headers.builder import (
     XFrameOptions,
     XXssProtection,
 )
-from kiss_headers.models import Header, Headers, lock_output_type
+from kiss_headers.models import Header, Headers, Attributes, lock_output_type
 from kiss_headers.version import VERSION, __version__

--- a/kiss_headers/__init__.py
+++ b/kiss_headers/__init__.py
@@ -87,5 +87,5 @@ from kiss_headers.builder import (
     XFrameOptions,
     XXssProtection,
 )
-from kiss_headers.models import Header, Headers, Attributes, lock_output_type
+from kiss_headers.models import Attributes, Header, Headers, lock_output_type
 from kiss_headers.version import VERSION, __version__

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -144,7 +144,7 @@ class Header(object):
             __index = __index if __index >= 0 else __index % len(self._attrs)
             key, value = self._attrs[__index]
         elif isinstance(__index, str):
-            key, value = __index, self._attrs[__index]
+            key, value = __index, self._attrs[__index]  # type: ignore
         else:
             raise ValueError(f"Cannot pop from Header using type {type(__index)}.")
 
@@ -346,7 +346,7 @@ class Header(object):
         """Provide a way to iter over a Header object. This will yield a Tuple of key, value.
         The value would be None if the key is a member without associated value."""
         for i in range(0, len(self._attrs)):
-            yield self._attrs[i]
+            yield self._attrs[i]  # type: ignore
 
     def __eq__(self, other: object) -> bool:
         """
@@ -435,7 +435,7 @@ class Header(object):
         if attr not in self._attrs:
             return None
 
-        return self._attrs[attr]
+        return self._attrs[attr]  # type: ignore
 
     def has_many(self, name: str) -> bool:
         """
@@ -463,7 +463,7 @@ class Header(object):
             )
 
         if item in self._attrs:
-            value = self._attrs[item]
+            value = self._attrs[item]  # type: ignore
         else:
             raise KeyError(
                 "'{item}' attribute is not defined within '{header}' header.".format(
@@ -471,13 +471,13 @@ class Header(object):
                 )
             )
 
-        if OUTPUT_LOCK_TYPE and not isinstance(value, list):
+        if OUTPUT_LOCK_TYPE and isinstance(value, str):
             value = [value]
 
         return (
-            unfold(unquote(value))
-            if not isinstance(value, list)
-            else [unfold(unquote(v)) for v in value]
+            unfold(unquote(value))  # type: ignore
+            if isinstance(value, str)
+            else [unfold(unquote(v)) for v in value]  # type: ignore
         )
 
     def __getattr__(self, item: str) -> Union[str, List[str]]:

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -1156,7 +1156,7 @@ class Attributes(object):
         if not isinstance(other, Attributes):
             raise NotImplementedError
 
-        if len(self._bag) != len(other._bag):
+        if len(self) != len(other):
             return False
 
         list_repr_a: List[Tuple[int, str, Optional[str]]] = list(self)
@@ -1204,7 +1204,7 @@ class Attributes(object):
         self, key: str, value: Optional[str], index: Optional[int] = None
     ) -> None:
         """"""
-        to_be_inserted: int = index if index is not None else len(self._bag)
+        to_be_inserted: int = index if index is not None else len(self)
 
         if index is not None:
             for attr in self._bag:

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -977,13 +977,14 @@ class Headers(object):
                 return True
             if isinstance(item, Header) and header == item:
                 return True
-
         return False
 
     def insert(self, __index: int, __header: Header) -> None:
         """Insert header before the given index."""
         if not isinstance(__header, Header):
-            raise TypeError(f"Cannot insert element of type {type(__header)} in Headers.")
+            raise TypeError(
+                f"Cannot insert element of type {type(__header)} in Headers."
+            )
 
         self._headers.insert(__index, __header)
 

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -142,7 +142,7 @@ class Header(object):
     def insert(
         self, __index: int, *__members: str, **__attributes: Optional[str]
     ) -> None:
-        """Experimental."""
+        """This method allows you to properly insert attributes into a Header instance."""
 
         __index = __index if __index >= 0 else __index % len(self._attrs)
 
@@ -1123,7 +1123,7 @@ class Attributes(object):
             self.insert(unquote(member), None)
 
     def __str__(self) -> str:
-        """"""
+        """Convert an Attributes instance to its string repr."""
         content: str = ""
 
         if len(self._bag) == 0:
@@ -1142,7 +1142,7 @@ class Attributes(object):
         return content
 
     def keys(self) -> List[str]:
-        """"""
+        """This method return a list of attribute name that have at least one value associated to them."""
         keys: List[str] = []
 
         for index, key, value in self:
@@ -1152,7 +1152,7 @@ class Attributes(object):
         return keys
 
     def __eq__(self, other: object) -> bool:
-        """"""
+        """Verify if two instance of Attributes are equal. We don't care about ordering."""
         if not isinstance(other, Attributes):
             raise NotImplementedError
 
@@ -1251,8 +1251,18 @@ class Attributes(object):
                 elif index_ > max_freed_index:
                     self._bag[attr][1][cur] -= 1
 
-    def __contains__(self, item: Union[str, Dict[str, List[str]]]) -> bool:
-        """"""
+    def __contains__(self, item: Union[str, Dict[str, Union[List[str], str]]]) -> bool:
+        """Verify if a member/attribute/value is in an Attributes instance. See examples bellow :
+        >>> attributes = Attributes(["application/xml", "q=0.9", "q=0.1"])
+        >>> "q" in attributes
+        True
+        >>> {"Q": "0.9"} in attributes
+        True
+        >>> "z" in attributes
+        False
+        >>> {"Q": "0.2"} in attributes
+        False
+        """
         if len(self._bag) == 0:
             return False
 
@@ -1272,6 +1282,7 @@ class Attributes(object):
 
     @property
     def last_index(self) -> Optional[int]:
+        """Simply output the latest index used in attributes. Index start from zero."""
         if len(self._bag) == 0:
             return None
 
@@ -1288,10 +1299,13 @@ class Attributes(object):
         return max_index
 
     def __len__(self) -> int:
+        """The length of an Attributes instance is equal to the last index plus one. Not by keys() length."""
         last_index: Optional[int] = self.last_index
         return last_index + 1 if last_index is not None else 0
 
     def __iter__(self) -> Iterator[Tuple[int, str, Optional[str]]]:
+        """Provide an iterator over all attributes with or without associated value.
+        For each entry, output a tuple of index, attribute and a optional value."""
         for i in range(0, len(self)):
             key, value = self[i]
             yield i, key, value

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -127,6 +127,34 @@ class Header(object):
         """Simply provide a deepcopy of a Header object. Pointer/Reference is free of the initial reference."""
         return Header(deepcopy(self.name), deepcopy(self.content))
 
+    def pop(self, __index: int) -> Tuple[str, Optional[str]]:
+        """Experimental."""
+
+        __index = __index if __index >= 0 else __index % len(self._attrs)
+
+        key, value = self._attrs[__index]
+
+        self._attrs.remove(key, __index)
+        self._content = str(self._attrs)
+
+        return key, value
+
+    def insert(
+        self, __index: int, *__members: str, **__attributes: Optional[str]
+    ) -> None:
+        """Experimental."""
+
+        __index = __index if __index >= 0 else __index % len(self._attrs)
+
+        for member in __members:
+            self._attrs.insert(member, None, __index)
+            __index += 1
+        for key, value in __attributes.items():
+            self._attrs.insert(key, value, __index)
+            __index += 1
+
+        self._content = str(self._attrs)
+
     def __iadd__(self, other: Union[str, "Header"]) -> "Header":
         """
         Allow you to assign-add any string to a Header instance. The string will be a new member of your header.

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -127,7 +127,9 @@ class Header(object):
         """Simply provide a deepcopy of a Header object. Pointer/Reference is free of the initial reference."""
         return Header(deepcopy(self.name), deepcopy(self.content))
 
-    def pop(self, __index: Union[int, str] = -1) -> Tuple[str, Optional[Union[str, List[str]]]]:
+    def pop(
+        self, __index: Union[int, str] = -1
+    ) -> Tuple[str, Optional[Union[str, List[str]]]]:
         """Permit to pop an element from a Header with a given index.
         >>> header = Header("X", "a; b=k; h; h; z=0; y=000")
         >>> header.pop(1)

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -127,14 +127,26 @@ class Header(object):
         """Simply provide a deepcopy of a Header object. Pointer/Reference is free of the initial reference."""
         return Header(deepcopy(self.name), deepcopy(self.content))
 
-    def pop(self, __index: int) -> Tuple[str, Optional[str]]:
-        """Experimental."""
+    def pop(self, __index: Union[int, str] = -1) -> Tuple[str, Optional[Union[str, List[str]]]]:
+        """Permit to pop an element from a Header with a given index.
+        >>> header = Header("X", "a; b=k; h; h; z=0; y=000")
+        >>> header.pop(1)
+        ('b', 'k')
+        >>> header.pop()
+        ('y', '000')
+        >>> header.pop('z')
+        ('z', '0')
+        """
 
-        __index = __index if __index >= 0 else __index % len(self._attrs)
+        if isinstance(__index, int):
+            __index = __index if __index >= 0 else __index % len(self._attrs)
+            key, value = self._attrs[__index]
+        elif isinstance(__index, str):
+            key, value = __index, self._attrs[__index]
+        else:
+            raise ValueError(f"Cannot pop from Header using type {type(__index)}.")
 
-        key, value = self._attrs[__index]
-
-        self._attrs.remove(key, __index)
+        self._attrs.remove(key, __index if isinstance(__index, int) else None)
         self._content = str(self._attrs)
 
         return key, value

--- a/kiss_headers/structures.py
+++ b/kiss_headers/structures.py
@@ -1,6 +1,13 @@
 from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping
-from typing import Any, Iterator, Optional, Tuple
+from typing import (
+    Any,
+    Iterator,
+    List,
+    MutableMapping as MutableMappingType,
+    Optional,
+    Tuple,
+)
 
 from kiss_headers.utils import normalize_str
 
@@ -79,3 +86,7 @@ class CaseInsensitiveDict(MutableMapping):
 
     def __repr__(self) -> str:
         return str(dict(self.items()))
+
+
+AttributeDescription = Tuple[List[Optional[str]], List[int]]
+AttributeBag = MutableMappingType[str, AttributeDescription]

--- a/kiss_headers/version.py
+++ b/kiss_headers/version.py
@@ -2,5 +2,5 @@
 Expose version
 """
 
-__version__ = "2.1.2"
+__version__ = "2.2.0"
 VERSION = __version__.split(".")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.10
-httpx>=0.10
 black
 pytest
 pytest-cov

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,35 @@
+import unittest
+from kiss_headers import Attributes
+
+
+class AttributesTestCase(unittest.TestCase):
+    def test_eq(self):
+        attr_a = Attributes(["a", "p=8a", "a", "XX"])
+        attr_b = Attributes(["p=8a", "a", "a", "XX"])
+        attr_c = Attributes(["p=8a", "a", "A", "Xx"])
+        attr_d = Attributes(["p=8a", "a", "A", "Xx", "XX=a"])
+        attr_e = Attributes(["p=8A", "a", "A", "Xx"])
+
+        self.assertEqual(
+            attr_a,
+            attr_b
+        )
+
+        self.assertEqual(
+            attr_a,
+            attr_c
+        )
+
+        self.assertNotEqual(
+            attr_a,
+            attr_d
+        )
+
+        self.assertNotEqual(
+            attr_a,
+            attr_e
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,4 +1,5 @@
 import unittest
+
 from kiss_headers import Attributes
 
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -10,26 +10,14 @@ class AttributesTestCase(unittest.TestCase):
         attr_d = Attributes(["p=8a", "a", "A", "Xx", "XX=a"])
         attr_e = Attributes(["p=8A", "a", "A", "Xx"])
 
-        self.assertEqual(
-            attr_a,
-            attr_b
-        )
+        self.assertEqual(attr_a, attr_b)
 
-        self.assertEqual(
-            attr_a,
-            attr_c
-        )
+        self.assertEqual(attr_a, attr_c)
 
-        self.assertNotEqual(
-            attr_a,
-            attr_d
-        )
+        self.assertNotEqual(attr_a, attr_d)
 
-        self.assertNotEqual(
-            attr_a,
-            attr_e
-        )
+        self.assertNotEqual(attr_a, attr_e)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_header_order.py
+++ b/tests/test_header_order.py
@@ -1,4 +1,5 @@
 import unittest
+
 from kiss_headers import Header
 
 

--- a/tests/test_header_order.py
+++ b/tests/test_header_order.py
@@ -3,24 +3,17 @@ from kiss_headers import Header
 
 
 class HeaderOrderingTest(unittest.TestCase):
-
     def test_keep_initial_order(self):
         header = Header("Content-Type", "a; b=k; h; h; z=0")
 
-        self.assertEqual(
-            ["a", "b", "h", "h", "z"],
-            header.attrs
-        )
+        self.assertEqual(["a", "b", "h", "h", "z"], header.attrs)
 
     def test_insertion_in_ordered_header(self):
         header = Header("Content-Type", "a; b=k; h; h; z=0")
 
         header.insert(2, ppp="nt")
 
-        self.assertEqual(
-            ["a", "b", "ppp", "h", "h", "z"],
-            header.attrs
-        )
+        self.assertEqual(["a", "b", "ppp", "h", "h", "z"], header.attrs)
 
     def test_pop_in_ordered_header(self):
 
@@ -28,40 +21,23 @@ class HeaderOrderingTest(unittest.TestCase):
 
         key, value = header.pop(2)
 
-        self.assertEqual(
-            key,
-            "h"
-        )
+        self.assertEqual(key, "h")
 
-        self.assertIsNone(
-            value
-        )
+        self.assertIsNone(value)
 
-        self.assertEqual(
-            ["a", "b", "h", "z"],
-            header.attrs
-        )
+        self.assertEqual(["a", "b", "h", "z"], header.attrs)
 
     def test_pop_negative_index(self):
         header = Header("Content-Type", "a; b=k; h; h; z=0")
 
         key, value = header.pop(-1)
 
-        self.assertEqual(
-            key,
-            "z"
-        )
+        self.assertEqual(key, "z")
 
-        self.assertEqual(
-            value,
-            "0"
-        )
+        self.assertEqual(value, "0")
 
-        self.assertEqual(
-            ["a", "b", "h", "h"],
-            header.attrs
-        )
+        self.assertEqual(["a", "b", "h", "h"], header.attrs)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_header_order.py
+++ b/tests/test_header_order.py
@@ -1,0 +1,67 @@
+import unittest
+from kiss_headers import Header
+
+
+class HeaderOrderingTest(unittest.TestCase):
+
+    def test_keep_initial_order(self):
+        header = Header("Content-Type", "a; b=k; h; h; z=0")
+
+        self.assertEqual(
+            ["a", "b", "h", "h", "z"],
+            header.attrs
+        )
+
+    def test_insertion_in_ordered_header(self):
+        header = Header("Content-Type", "a; b=k; h; h; z=0")
+
+        header.insert(2, ppp="nt")
+
+        self.assertEqual(
+            ["a", "b", "ppp", "h", "h", "z"],
+            header.attrs
+        )
+
+    def test_pop_in_ordered_header(self):
+
+        header = Header("Content-Type", "a; b=k; h; h; z=0")
+
+        key, value = header.pop(2)
+
+        self.assertEqual(
+            key,
+            "h"
+        )
+
+        self.assertIsNone(
+            value
+        )
+
+        self.assertEqual(
+            ["a", "b", "h", "z"],
+            header.attrs
+        )
+
+    def test_pop_negative_index(self):
+        header = Header("Content-Type", "a; b=k; h; h; z=0")
+
+        key, value = header.pop(-1)
+
+        self.assertEqual(
+            key,
+            "z"
+        )
+
+        self.assertEqual(
+            value,
+            "0"
+        )
+
+        self.assertEqual(
+            ["a", "b", "h", "h"],
+            header.attrs
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Pull Request

That PR is not BC-Break.
Once merged, this package will be available as version 2.2.0 on PyPi.

### My patch is about
- [ ] :bug: Bugfix 
- [ ] :arrow_up: Improvement
- [x] :pencil: Documentation 
- [ ] :heavy_check_mark: Tests
- [x] :sparkle: Feature

### Checklist
- [x] I accept that my PR will be distributed under the MIT license.
- [x] Test cases added for changed code if necessary.

## Describe what you have changed in this PR.

In my opinion, what was critically missing from this package is the ability to alter header attributes based on a position. eg. insert this before position 0.
This PR brings a new class into `models.py` called `Attributes`. Before that, attributes were handled into the Header instance by a `structure.CaseInsensibleDict`.

```python
from kiss_headers import Header

if __name__ == "__main__":

    header = Header("Content-Type", "text/html; charset=UTF-8; format=flowed; text/html=ALLO")

    print(header)  
    # output: 'text/html; charset=UTF-8; format=flowed; text/html=ALLO'

    header.insert(1, "hello-world")

    print(header)  
    # output: 'text/html; hello-world; charset="UTF-8"; format="flowed"; text/html="ALLO"'

    header.insert(5, "zut", qwerty="UTF-47")
    
    print(header)
    # output: 'text/html; hello-world; charset="UTF-8"; format="flowed"; text/html="ALLO"; zut; qwerty="UTF-47"' 
```