### PR TITLE
:bug: Un/escape the double quote char in attrs values

### DIFF
--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -14,6 +14,8 @@ from kiss_headers.utils import (
     unfold,
     unpack_protected_keyword,
     unquote,
+    escape_double_quote,
+    unescape_double_quote,
 )
 
 OUTPUT_LOCK_TYPE: bool = False
@@ -1203,7 +1205,7 @@ class Attributes(object):
                     self.insert(unquote(member), None)
                     continue
 
-                self.insert(key, unquote(value))
+                self.insert(key, unescape_double_quote(unquote(value)))
                 continue
 
             self.insert(unquote(member), None)
@@ -1220,7 +1222,9 @@ class Attributes(object):
 
             if value is not None:
                 content += '{semi_colon_r}{key}="{value}"'.format(
-                    key=key, value=value, semi_colon_r="; " if content != "" else "",
+                    key=key,
+                    value=escape_double_quote(value),
+                    semi_colon_r="; " if content != "" else "",
                 )
             else:
                 content += "; " + key if content != "" else key

--- a/kiss_headers/models.py
+++ b/kiss_headers/models.py
@@ -4,6 +4,7 @@ from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Type, Union
 
 from kiss_headers.structures import AttributeBag, CaseInsensitiveDict
 from kiss_headers.utils import (
+    escape_double_quote,
     extract_comments,
     header_content_split,
     header_name_to_class,
@@ -11,11 +12,10 @@ from kiss_headers.utils import (
     normalize_list,
     normalize_str,
     prettify_header_name,
+    unescape_double_quote,
     unfold,
     unpack_protected_keyword,
     unquote,
-    escape_double_quote,
-    unescape_double_quote,
 )
 
 OUTPUT_LOCK_TYPE: bool = False

--- a/kiss_headers/utils.py
+++ b/kiss_headers/utils.py
@@ -89,6 +89,8 @@ def header_content_split(string: str, delimiter: str) -> List[str]:
     ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:50.0) Gecko/20100101 Firefox/50.0']
     >>> header_content_split("text/html; charset=UTF-8", ";")
     ['text/html', 'charset=UTF-8']
+    >>> header_content_split('text/html; charset="UTF-\\\"8"', ";")
+    ['text/html', 'charset="UTF-"8"']
     """
     if len(delimiter) != 1 or delimiter not in {";", ",", " "}:
         raise ValueError("Delimiter should be either semi-colon, a coma or a space.")
@@ -427,3 +429,25 @@ def extract_encoded_headers(payload: bytes) -> Tuple[str, bytes]:
             break
 
     return result, b"\r\n".join(lines[index + 1 :])
+
+
+def unescape_double_quote(content: str) -> str:
+    """
+    Replace escaped double quote in content by removing the backslash.
+    >>> unescape_double_quote(r'UTF\"-8')
+    'UTF"-8'
+    >>> unescape_double_quote(r'UTF"-8')
+    'UTF"-8'
+    """
+    return content.replace(r"\"", '"')
+
+
+def escape_double_quote(content: str) -> str:
+    r"""
+    Replace not escaped double quote in content by adding a backslash beforehand.
+    >>> escape_double_quote(r'UTF\"-8')
+    'UTF\\"-8'
+    >>> escape_double_quote(r'UTF"-8')
+    'UTF\\"-8'
+    """
+    return unescape_double_quote(content).replace('"', r"\"")

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,6 +1,7 @@
 import unittest
 
 from kiss_headers import Attributes
+from kiss_headers.utils import header_content_split
 
 
 class AttributesTestCase(unittest.TestCase):
@@ -21,6 +22,19 @@ class AttributesTestCase(unittest.TestCase):
             self.assertNotEqual(attr_a, attr_d)
 
             self.assertNotEqual(attr_a, attr_e)
+
+    def test_esc_double_quote(self):
+
+        with self.subTest(
+            "Ensure that the double quote character is handled correctly."
+        ):
+            attributes = Attributes(
+                header_content_split(r'text/html; charset="UTF-\"8"', ";")
+            )
+
+            self.assertEqual(attributes["charset"], 'UTF-"8')
+
+            self.assertEqual(str(attributes), r'text/html; charset="UTF-\"8"')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Pull Request

### My patch is about
- [x] :bug: Bugfix 
- [ ] :arrow_up: Improvement
- [ ] :pencil: Documentation
- [ ] :heavy_check_mark: Tests
- [ ] :sparkle: Feature

### Checklist
- [x] I accept that my PR will be distributed under the MIT license.
- [x] Test cases added for changed code if necessary.

## Describe what you have changed in this PR.

Close #37 

- **Bugfix:** The double-quote character wasn't handled correctly inside attributes values.

```python
from kiss_headers.utils import header_content_split
from kiss_headers import Attributes

if __name__ == "__main__":
    attributes = Attributes(header_content_split(r'text/html; charset="UTF-\"8"', ";"))

    # 1) Retrieve the value
    print(attributes["charset"])   # output: 'UTF-"8'
    # 2) cast to headers str
    print(attributes)  # output: 'text/html; charset="UTF-\"8"'
```