### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,29 @@ exclude: 'docs/'
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+      - id: codespell # See pyproject.toml for args
+        additional_dependencies:
+          - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.1
+    rev: v0.15.10
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [ --fix, --target-version=py37 ]
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.20.1
     hooks:
       - id: mypy
         args: [ --check-untyped-defs ]

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ json_repr: str = dumps(
     indent=4
 )
 
-print(json_repr)  # See the result bellow
+print(json_repr)  # See the result below
 
 # Additionally, how to parse the JSON repr to Headers again
 headers = parse_it(json_repr)  # Yes! that easy!

--- a/docs/APIs/custom-headers.md
+++ b/docs/APIs/custom-headers.md
@@ -865,7 +865,7 @@ the browser blocks no-cors cross-origin/cross-site requests to the given resourc
 This class is a helper to create ready-to-use Header object with creation assistance.
 Should NOT be instantiated.
 Use this class as a direct parent for creating ready-to-use header object. Inspire yourself with already defined
-class bellow this one.
+class below this one.
 
 :param initial_content: Initial content of the Header if any.
 :param kwargs: Provided args. Any key that associate a None value are just ignored.

--- a/docs/APIs/others.md
+++ b/docs/APIs/others.md
@@ -285,7 +285,7 @@ unfold("eqHS2AQD+hfNNlTiLej73CiBUGVQifX4watAaxUkdjGeH578i7n3Wwcdw2nLz+U0bH\n    
 > `def unpack_protected_keyword(name: str) -> str`
 
 
-By choice this project aim to allow developper to access header or attribute in header by using the property
+By choice this project aim to allow developer to access header or attribute in header by using the property
 notation. Some keyword are protected by the language itself. So :
 When starting by a number, prepend a underscore to it. When using a protected keyword, append a underscore to it.
 ```python

--- a/docs/advanced-header.md
+++ b/docs/advanced-header.md
@@ -16,7 +16,7 @@ dict(header)  # output: {'text/html': None, 'charset': 'UTF-8'}
 
 ### Setup
 
-If you wish to run bellow examples, first do :
+If you wish to run below examples, first do :
 
 ```python
 from kiss_headers import parse_it

--- a/docs/advanced-headers.md
+++ b/docs/advanced-headers.md
@@ -20,7 +20,7 @@ headers.to_dict()  # output: {'Content-Type': 'application/json', 'Allow': 'POST
 
 ### Setup
 
-If you wish to run bellow examples, first do :
+If you wish to run below examples, first do :
 
 ```python
 from kiss_headers import parse_it

--- a/docs/the-theory.md
+++ b/docs/the-theory.md
@@ -23,7 +23,7 @@ In most headers, the semi-colon `;` character is used as a separator. But you ca
 Here's how I understand those two separators.
 
 - The single comma indicate that their is multiple entries for the same headers.
-- The semi-colon separate members inside the same entry and therefor cannot be interpreted separately.
+- The semi-colon separate members inside the same entry and therefore cannot be interpreted separately.
 
 Writing `Accept: text/html, application/json;q=0.8` is another way to write :
 

--- a/src/kiss_headers/builder.py
+++ b/src/kiss_headers/builder.py
@@ -26,7 +26,7 @@ class CustomHeader(Header):
     This class is a helper to create ready-to-use Header object with creation assistance.
     Should NOT be instantiated.
     Use this class as a direct parent for creating ready-to-use header object. Inspire yourself with already defined
-    class bellow this one.
+    class below this one.
     """
 
     __squash__: bool = False  # This value indicate whenever the representation of multiple entries should be squashed into one content.

--- a/src/kiss_headers/models.py
+++ b/src/kiss_headers/models.py
@@ -1383,7 +1383,7 @@ class Attributes:
                     self._bag[attr][1][cur] -= 1
 
     def __contains__(self, item: str | dict[str, list[str] | str]) -> bool:
-        """Verify if a member/attribute/value is in an Attributes instance. See examples bellow :
+        """Verify if a member/attribute/value is in an Attributes instance. See examples below :
         >>> attributes = Attributes(["application/xml", "q=0.9", "q=0.1"])
         >>> "q" in attributes
         True


### PR DESCRIPTION
## Pull Request

### My patch is about
- [ ] :bug: Bugfix
- [x] :arrow_up: Improvement
- [ ] :pencil: Documentation
- [ ] :heavy_check_mark: Tests
- [ ] :sparkle: Feature

### Checklist
- [x] I accept that my PR will be distributed under the MIT license.
- [x] Test cases added for changed code if necessary.


## Describe what you have changed in this PR.
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v5.0.0 -> v6.0.0
[https://github.com/astral-sh/ruff-pre-commit] updating v0.9.1 -> v0.15.10
[https://github.com/pre-commit/mirrors-mypy] updating v1.14.1 -> v1.20.1
```
% `pre-commit run --all-files`

* Update `ruff (legacy alias)` to `ruff-check` -- https://github.com/astral-sh/ruff

---
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell`
```
./README.md:201: bellow ==> below
./docs/advanced-header.md:19: bellow ==> below
./docs/advanced-headers.md:23: bellow ==> below
./docs/the-theory.md:26: therefor ==> therefore
./docs/APIs/custom-headers.md:868: bellow ==> below
./docs/APIs/others.md:288: developper ==> developer
./src/kiss_headers/builder.py:29: bellow ==> below
./src/kiss_headers/models.py:1386: bellow ==> below
```
% `codespell --write-changes` 